### PR TITLE
[output] Disable repetitive and non-very informative output.

### DIFF
--- a/shared/render_results.ml
+++ b/shared/render_results.ml
@@ -388,6 +388,9 @@ coq_opam_packages
              proportional_difference__faults__width precision proportional_difference__faults);
 
 print_string (vertical_separator "└" "┴" "┘");
+
+(* ejgallego: disable this as it is very verbose and brings up little info in the log. *)
+if false then begin
 printf "
 
 PDIFF = proportional difference between measurements done for the NEW and the OLD Coq version
@@ -425,3 +428,4 @@ Columns:
      (In other words, \"%%F\" quantity provided by the \"/usr/bin/time\" command.)
 
 " new_coq_version old_coq_version;
+end

--- a/two_points_on_the_same_branch.sh
+++ b/two_points_on_the_same_branch.sh
@@ -363,17 +363,18 @@ installable_coq_opam_packages=
 
 for coq_opam_package in $coq_opam_packages; do
     echo "DEBUG: coq_opam_package = $coq_opam_package"
+    opam show $coq_opam_package || continue 2
 
   for RUNNER in NEW OLD; do
     # perform measurements for the NEW/OLD commit (provided by the user)
     if [ $RUNNER = "NEW" ]; then
       export OPAMROOT="$new_opam_root"
+      echo "Testing NEW commit"
     else
       export OPAMROOT="$old_opam_root"
+      echo "Testing OLD commit"
     fi
     . "$OPAMROOT"/opam-init/init.sh
-
-    opam show $coq_opam_package || continue 2
 
     # If a given OPAM-package was already installed
     # (as a dependency of some OPAM-package that we have benchmarked before),


### PR DESCRIPTION
The repeated output of what the columns mean do really make the logs
unreadable; if anything, this info should be printed just once or even
better be present in the README.