### PR TITLE
Make timelog2html more portable

### DIFF
--- a/timelog2html
+++ b/timelog2html
@@ -1,4 +1,4 @@
-#!/usr/bin/lua5.1
+#!/usr/bin/env lua5.1
 
 args = {...}
 


### PR DESCRIPTION
E.g. Homebrew package manager on macOS installs
binaries into /usr/local/bin by default.