### PR TITLE
[opam] Update to OPAM 2.0 + allow testing of experimental compiler versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 addons:
   apt:
     packages:
-    - opam
     - linux-tools-generic     # /usr/bin/perf
     - time                    # /usr/bin/time
     - ca-certificates
@@ -21,14 +20,13 @@ env:
   - BUILD_ID="travis"
   - number_of_processors="2"
   - num_of_iterations="2"
-  - coq_opam_packages="coq-sf-lf coq-mathcomp-ssreflect"
-  - new_ocaml_switch="4.06.1"
+  - coq_opam_packages="coq-bignums coq-mathcomp-ssreflect"
+  - new_ocaml_switch="4.07.1"
   - new_coq_repository="https://github.com/coq/coq.git"
-  - new_coq_commit="850dfbf59f52b0d3dcba237ee2af5ce99fd1bcd2"
-  # OPAM 1 cannot use 4.07.1
-  - old_ocaml_switch="4.07.0"
+  - new_coq_commit="163000a8326ad559d2a0581608f2ccc83fe3beee"
+  - old_ocaml_switch="4.06.1"
   - old_coq_repository="https://github.com/ejgallego/coq.git"
-  - old_coq_commit="40464248828e0f09ffd98e9602020975c0bcf82d"
+  - old_coq_commit="47c6f0ddacf340d4027fce181ee8ac8a0369188f"
   - new_coq_opam_archive_git_uri="https://github.com/coq/opam-coq-archive.git"
   - new_coq_opam_archive_git_branch="master"
   matrix:
@@ -38,9 +36,8 @@ env:
 # linux-tools on Travis is a complicated issue
 install:
 - sudo apt-get install -y -qq linux-tools-`uname -r`
-# - sudo curl -sL https://github.com/ocaml/opam/releases/download/1.2.2/opam-1.2.2-x86_64-Linux -o /usr/bin/opam
-# - sudo chmod 755 /usr/bin/opam
-# - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.1/opam-2.0.1-x86_64-linux -o /usr/bin/opam
+- sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.2/opam-2.0.2-x86_64-linux -o /usr/bin/opam
+- sudo chmod +x /usr/bin/opam
 # - opam init -c "$COMPILER" --disable-sandboxing
 # - opam switch set "$COMPILER"
 # - eval $(opam env)


### PR DESCRIPTION
- we add the ocaml-pr-repository switch as to allow testing of
  experimental copmiler versions.
- we disable the install of camlp5 to make the above work.

We should add a `coq_dependencies` field so we could go back to
testing older Coq versions, even tho #58 would make this unnecessary.