### PR TITLE
Don't require package list to be topologically sorted

### DIFF
--- a/sort-by-deps.ml
+++ b/sort-by-deps.ml
@@ -1,0 +1,33 @@
+#!/usr/bin/env ocaml
+
+let get_pkg_name arg =
+  List.nth (String.split_on_char ':' arg) 0
+
+let get_pkg_deps arg =
+  String.split_on_char ',' (List.nth (String.split_on_char ':' arg) 1)
+
+let split_pkg arg = get_pkg_name arg, get_pkg_deps arg
+
+let depends_on arg1 arg2 =
+  let pkg1, deps1 = split_pkg arg1 in
+  let pkg2, deps2 = split_pkg arg2 in
+  pkg1 != pkg2 && List.mem pkg2 deps1
+
+let rec sort = function
+  | [], [] -> []
+  | [], deferred -> sort (List.rev deferred, [])
+  | arg :: rest, deferred ->
+    (* check if any remaining package reverse-depends on this one *)
+    if List.exists (fun other_arg -> depends_on arg other_arg) rest
+    then (* defer this package *)
+      sort (rest, arg :: deferred)
+    else (* emit this package, and then try again with any deferred packages *)
+      arg :: sort (List.rev deferred @ rest, [])
+
+let main () =
+  let args = Array.to_list Sys.argv in
+  let pkgs = List.tl args in
+  let sorted_pkgs = sort (pkgs, []) in
+  Printf.printf "%s\n%!" (String.concat " " (List.map get_pkg_name sorted_pkgs))
+
+let () = main ()

--- a/sort-by-deps.sh
+++ b/sort-by-deps.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+program_name="$0"
+program_path=$(readlink -f "${program_name%/*}")
+
+# We add || true (which may not be needed without set -e) to be
+# explicit about the fact that this script does not fail even if `opam
+# install --show-actions` does, e.g., because of a non-existent
+# package
+#
+# TODO: Figure out how to use the OPAM API
+# (https://opam.ocaml.org/doc/api/) to call this from OCaml.
+for i in "$@"; do
+    echo -n "$i:"; ((echo -n "$(opam install --show-actions "$i" | grep -o '∗\s*install\s*[^ ]*' | sed 's/∗\s*install\s*//g')" | tr '\n' ',') || true); echo
+done | xargs ocaml "${program_path}/sort-by-deps.ml"

--- a/two_points_on_the_same_branch.sh
+++ b/two_points_on_the_same_branch.sh
@@ -208,13 +208,20 @@ old_coq_commit_long="$COQ_HASH_LONG"
 # --------------------------------------------------------------------------------
 # Measure the compilation times of the specified OPAM packages in both switches
 
+# Sort the opam packages
+sorted_coq_opam_packages=$("${program_path}/sort-by-deps.sh" ${coq_opam_packages})
+if [ ! -z "$BENCH_DEBUG" ]
+then
+   echo "DEBUG: sorted_coq_opam_packages = ${sorted_coq_opam_packages}"
+fi
+
 # Generate per line timing info in devs that use coq_makefile
 export TIMING=1
 
 # The following variable will be set in the following cycle:
 installable_coq_opam_packages=
 
-for coq_opam_package in $coq_opam_packages; do
+for coq_opam_package in $sorted_coq_opam_packages; do
 
     if [ ! -z "$BENCH_DEBUG" ]; then
         opam list
@@ -289,7 +296,7 @@ for coq_opam_package in $coq_opam_packages; do
     # --------------------------------------------------------------
 
     # Print the intermediate results after we finish benchmarking each OPAM package
-    if [ "$coq_opam_package" = "$(echo $coq_opam_packages | sed 's/ /\n/g' | tail -n 1)" ]; then
+    if [ "$coq_opam_package" = "$(echo $sorted_coq_opam_packages | sed 's/ /\n/g' | tail -n 1)" ]; then
 
         # It does not make sense to print the intermediate results when
         # we finished bechmarking the very last OPAM package because the
@@ -343,7 +350,7 @@ echo "INFO: workspace = https://ci.inria.fr/coq/view/benchmarking/job/$JOB_NAME/
 if [ -z "$installable_coq_opam_packages" ]; then
     # Tell the user that none of the OPAM-package(s) the user provided
     # /are installable.
-    printf "\n\nINFO: failed to install: $coq_opam_packages"
+    printf "\n\nINFO: failed to install: $sorted_coq_opam_packages"
     exit 1
 else
     echo "DEBUG: $program_path/shared/render_results.ml "$log_dir" $num_of_iterations $new_coq_commit_long $old_coq_commit_long 0 user_time_pdiff $installable_coq_opam_packages"
@@ -357,7 +364,7 @@ else
     echo INFO: New Coq version
     git log -n 1 "$new_coq_commit"
 
-    not_installable_coq_opam_packages=`comm -23 <(echo $coq_opam_packages | sed 's/ /\n/g' | sort | uniq) <(echo $installable_coq_opam_packages | sed 's/ /\n/g' | sort | uniq) | sed 's/\t//g'`
+    not_installable_coq_opam_packages=`comm -23 <(echo $sorted_coq_opam_packages | sed 's/ /\n/g' | sort | uniq) <(echo $installable_coq_opam_packages | sed 's/ /\n/g' | sort | uniq) | sed 's/\t//g'`
 
     exit_code=0
 

--- a/two_versions.sh
+++ b/two_versions.sh
@@ -125,9 +125,13 @@ done
 
 export OPAMROOT="$working_dir/.opam"
 
-for coq_opam_package in $coq_opam_packages; do
+# Sort the opam packages
+sorted_coq_opam_packages=$("${program_path}/sort-by-deps.sh" ${coq_opam_packages})
+echo "DEBUG: sorted_coq_opam_packages = ${sorted_coq_opam_packages}"
+
+for coq_opam_package in $sorted_coq_opam_packages; do
     echo DEBUG: coq_opam_package = $coq_opam_package
-    
+
     # perform measurements with the $older_coq_version
     rm -r -f "$OPAMROOT"
     cp -r "$OPAMROOT.$older_coq_version" "$OPAMROOT"
@@ -156,4 +160,4 @@ done
 export OPAMROOT=
 echo "DEBUG: ocamlfind = `which ocamlfind`"
 echo "DEBUG: ocaml = `which ocaml`"
-$program_path/shared/bench.ml $working_dir $num_of_iterations $newer_coq_version $older_coq_version 0 package_name $coq_opam_packages
+$program_path/shared/bench.ml $working_dir $num_of_iterations $newer_coq_version $older_coq_version 0 package_name $sorted_coq_opam_packages


### PR DESCRIPTION
Instead we perform a stable sort using the dependencies generated by paring the output of `opam install --show-actions`.  Note that we depend on the output actions matching `∗\s*install\s*<package-name-without-spaces>`.  Note the special unicode star character.  Perhaps we should only look for `^\s*.\s*intstall\s*` instead, in case opam changes what character they use to indicate an install action?  Or `\sinstall\s*`, in case the character goes away entirely?  (But then we have a bit of trouble if we ever try to install a package called "install".)

We do a manual sort because we want to preserve user-ordering insofar as it is possible.  In particular, we want to allow bench initiators to declare that certain packages should be installed as late as possible, by putting them at the end of the list, so that if they interrupt the bench early, they get the packages they care most about.  (I could not figure out how to get `opam install --show-actions` to be a stable sort.)

Closes #3