### PR TITLE
[opam] Update ocaml-pr-repos to our own git repos

### DIFF
--- a/two_points_on_the_same_branch.sh
+++ b/two_points_on_the_same_branch.sh
@@ -166,7 +166,7 @@ create_opam() {
     # Allow beta compiler switches
     opam repo add -q --set-default beta https://github.com/ocaml/ocaml-beta-repository.git
     # Allow experimental compiler switches
-    opam repo add -q --set-default ocaml-pr https://github.com/ocaml/ocaml-pr-repository.git
+    opam repo add -q --set-default ocaml-pr https://github.com/ejgallego/ocaml-pr-repository.git
     # Rest of default switches
     opam repo add -q --set-default iris-dev "https://gitlab.mpi-sws.org/FP/opam-dev.git"
 


### PR DESCRIPTION
The OCaml PR repository has been abandoned for a while, update the
pointer in the bench to our own private copy.