### PR TITLE
Make coq-bench per-line timing script work with coq-lambda-rust

### DIFF
--- a/two_points_on_the_same_branch.sh
+++ b/two_points_on_the_same_branch.sh
@@ -318,8 +318,11 @@ for coq_opam_package in $sorted_coq_opam_packages; do
 
     # Generate HTML report for LAST run
 
-    new_base_path=$new_ocaml_switch/.opam-switch/build/$coq_opam_package.dev/
-    old_base_path=$old_ocaml_switch/.opam-switch/build/$coq_opam_package.dev/
+    # N.B. Not all packages end in .dev, e.g., coq-lambda-rust uses .dev.timestamp.
+    # So we use a wildcard to catch such packages.  This will have to be updated if
+    # ever there is a package that uses some different naming scheme.
+    new_base_path=$new_ocaml_switch/.opam-switch/build/$coq_opam_package.dev*/
+    old_base_path=$old_ocaml_switch/.opam-switch/build/$coq_opam_package.dev*/
     for vo in `cd $new_opam_root/$new_base_path/; find -name '*.vo'`; do
         if [ -e $old_opam_root/$old_base_path/${vo%%o}.timing -a \
 	        -e $new_opam_root/$new_base_path/${vo%%o}.timing ]; then


### PR DESCRIPTION
When you `opam install coq-lambda-rust`, you get something like `coq-lambda-rust.dev.2020-03-21.0.73f3ded1`, not `coq-lambda-rust.dev`.  This is a conservative change that supports such timestamping.  This will go wrong if any packages ever decide to name their dev versions something other than `package-name.dev` followed by something.  We could be more permissive and allow `$coq_opam_package*`, but then if two packages share the same prefix, things will go wrong.  It would be nice if we could get opam to give us the name of the folder, but this should work for the foreseeable future.

Note that the wildcard gets expanded on the calls to `cd` and `timelog2html`.  Things will go wrong if there are multiple folders matching the pattern (`cd` will fail with `-bash: cd: too many arguments`; `find` will look for all the `.vo` files in the current directory (not sure what that will be at this point), and `timelog2html` will get too many arguments (not sure what it will do with them)).  I think this is okay, though, since we don't expect there to be multiple matches, unless the naming scheme changes drastically (or, I suppose, if we end up with both `coq-A` and `coq-A.dev` as separate opam packages, giving us the folders `coq-A.dev` and `coq-A.dev.dev`; hopefully no-one does this.)

cc @ppedrot 